### PR TITLE
feat: add chromosome scatter mode (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The wizard will:
 4. Detect genome build (GRCh38/GRCh37) from the reference filename
 5. Auto-scan for dbNSFP database matching the detected build
 6. Auto-scan for known extra annotation VCFs (ClinVar, HGMD, COSMIC, dbscSNV, SPIDEX)
-7. Configure scatter mode (none/interval) with canonical contigs from `.dict` file
+7. Configure scatter mode (none/chromosome/interval) with canonical contigs from `.dict` file
 8. Show summary and confirm before writing
 
 Any databases not found automatically get `EDIT_ME:` placeholders in the generated config.
@@ -132,7 +132,12 @@ python scripts/generate_config.py \
     --vcf-folder results/variant_calls/ \
     --genome-build GRCh37
 
-# Enable scatter mode
+# Enable chromosome scatter mode (simpler, ~24 parallel units)
+python scripts/generate_config.py \
+    --vcf-folder results/variant_calls/ \
+    --scatter-mode chromosome
+
+# Enable interval scatter mode (GATK-based, configurable count)
 python scripts/generate_config.py \
     --vcf-folder results/variant_calls/ \
     --scatter-mode interval --scatter-count 50
@@ -154,7 +159,7 @@ python scripts/generate_config.py --vcf-folder /path/to/vcfs --overwrite
 | `--annotation-dir PATH` | *(auto-scan)* | Extra annotation VCFs directory |
 | `--genome-build` | *(auto-detect)* | `GRCh37` or `GRCh38` |
 | `--output-dir PATH` | *(inferred)* | Pipeline output directory (inferred from `--vcf-folder`) |
-| `--scatter-mode` | `none` | `none` or `interval` |
+| `--scatter-mode` | `none` | `none`, `chromosome`, or `interval` |
 | `--scatter-count` | `100` | Number of scatter intervals |
 | `--dry-run` | off | Preview without writing |
 | `--overwrite` | off | Overwrite existing config files |
@@ -196,20 +201,20 @@ snpsift:
   dbnsfp_fields: "aaref,aaalt,aapos,SIFT_pred,..."  # auto-selected for dbNSFP v4 or v5
 
 scatter:
-  mode: "none"                         # "none" or "interval"
+  mode: "none"                         # "none", "chromosome", or "interval"
   count: 100                           # intervals (for interval mode)
-  canonical_contigs: []                # contigs to include when scattering
+  canonical_contigs: []                # contigs to include (chromosome + interval modes)
 
 extra_annotations: []                  # optional step-wise SnpSift annotate
 ```
 
 | Section | Key settings |
 |---------|-------------|
-| `ref` | Reference genome path and dictionary (required for scatter mode) |
+| `ref` | Reference genome path and dictionary (required for chromosome/interval scatter) |
 | `paths` | Input VCF folder, output folder, samples TSV path |
 | `snpeff` | snpEff database name and extra flags |
 | `snpsift` | dbNSFP database path and annotation fields (version-aware: v4 vs v5) |
-| `scatter` | Parallelization mode (`"none"` or `"interval"`) and interval count |
+| `scatter` | Parallelization mode (`"none"`, `"chromosome"`, or `"interval"`) and interval count |
 | `extra_annotations` | Optional list of extra VCF annotation steps |
 
 See [`config/README.md`](config/README.md) for full field reference.
@@ -347,12 +352,12 @@ workflow/Snakefile
     ├── rules/helpers.py       Pure Python functions (unit-testable)
     ├── rules/snpeff.smk       snpEff variant annotation
     ├── rules/snpsift.smk      SnpSift varType, dbNSFP, extra annotations, finalize
-    └── rules/scatter.smk      Conditional scatter/gather (GATK-based)
+    └── rules/scatter.smk      Conditional scatter/gather (chromosome or GATK-based)
 ```
 
 ### Annotation DAG
 
-Per sample (per scatter interval if `scatter.mode: "interval"`):
+Per sample (per scatter unit if `scatter.mode` is `"chromosome"` or `"interval"`):
 
 ```
 Input VCF
@@ -362,6 +367,14 @@ Input VCF
     ├── annotation_step (1..N, if extra_annotations defined) [temp]
     ├── finalize_annotation                                  [temp]
     └── rename_no_scatter / concatenate_annotated_vcfs       → final .annotated.vcf.gz
+```
+
+### Scatter/Gather DAG (mode: "chromosome")
+
+```
+Input VCF
+    └── scatter_vcf_chromosome (bcftools view -r, per sample x chromosome) [temp]
+        └── annotation pipeline (per chromosome) → concatenate → final VCF
 ```
 
 ### Scatter/Gather DAG (mode: "interval")

--- a/README.md
+++ b/README.md
@@ -371,8 +371,10 @@ Input VCF
 
 ### Scatter/Gather DAG (mode: "chromosome")
 
+Requires tabix-indexed input VCFs (`.vcf.gz` + `.tbi`).
+
 ```
-Input VCF
+Input VCF (.vcf.gz + .tbi)
     └── scatter_vcf_chromosome (bcftools view -r, per sample x chromosome) [temp]
         └── annotation pipeline (per chromosome) → concatenate → final VCF
 ```

--- a/config/README.md
+++ b/config/README.md
@@ -14,16 +14,16 @@ Unified pipeline configuration. All paths are relative to the repository root.
 | `snpeff.database` | string | snpEff database name (e.g., `GRCh37.p13`) |
 | `snpsift.dbnsfp_db` | string | Path to dbNSFP database file (v4.x or v5.x) |
 | `snpsift.dbnsfp_fields` | string | Comma-separated dbNSFP fields (auto-selected for v4/v5 by config generator) |
-| `scatter.mode` | string | `"interval"` or `"none"` |
+| `scatter.mode` | string | `"none"`, `"chromosome"`, or `"interval"` |
 
-### Required for Scatter Mode (`scatter.mode: "interval"`)
+### Required for Scatter Modes (`scatter.mode: "chromosome"` or `"interval"`)
 
 | Field | Description |
 |-------|-------------|
 | `ref.genome` | Path to reference genome FASTA |
 | `ref.dict` | Path to reference sequence dictionary |
-| `scatter.count` | Number of scatter intervals (default: 100) |
-| `scatter.canonical_contigs` | List of canonical contigs to include |
+| `scatter.count` | Number of scatter intervals (default: 100, interval mode only) |
+| `scatter.canonical_contigs` | List of canonical contigs to include (used by both chromosome and interval modes) |
 
 ### Optional Fields
 

--- a/profiles/default/config.v8+.yaml
+++ b/profiles/default/config.v8+.yaml
@@ -31,6 +31,7 @@ set-threads:
   scatter_intervals_by_ns: 1
   split_intervals: 4
   scatter_vcf: 2
+  scatter_vcf_chromosome: 2
   concatenate_annotated_vcfs: 4
 
 # Per-rule resource overrides
@@ -64,6 +65,10 @@ set-resources:
   scatter_vcf:
     mem_mb: 8192
     runtime: 1440
+    cpus_per_task: 2
+  scatter_vcf_chromosome:
+    mem_mb: 4000
+    runtime: 720
     cpus_per_task: 2
   concatenate_annotated_vcfs:
     mem_mb: 8192

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -1013,15 +1013,18 @@ def _interactive_wizard() -> None:
     print()
 
     # --- Step 8: Scatter mode ---
-    scatter_mode = _prompt_choice("Scatter mode", choices=["none", "interval"], default="none")
+    scatter_mode = _prompt_choice(
+        "Scatter mode", choices=["none", "chromosome", "interval"], default="none"
+    )
     scatter_config: dict[str, Any] = {"mode": scatter_mode, "count": 100, "canonical_contigs": []}
 
-    if scatter_mode == "interval":
-        count_str = _prompt("  Number of scatter intervals", default="100")
-        try:
-            scatter_config["count"] = int(count_str)
-        except ValueError:
-            print("  Invalid number, using default 100.")
+    if scatter_mode in ("chromosome", "interval"):
+        if scatter_mode == "interval":
+            count_str = _prompt("  Number of scatter intervals", default="100")
+            try:
+                scatter_config["count"] = int(count_str)
+            except ValueError:
+                print("  Invalid number, using default 100.")
 
         # Parse canonical contigs from .dict or use defaults
         contigs = parse_canonical_contigs(ref_data.get("dict"), build)
@@ -1131,7 +1134,7 @@ def main() -> None:
         "--scatter-mode",
         type=str,
         default="none",
-        choices=["none", "interval"],
+        choices=["none", "chromosome", "interval"],
         help="Scatter mode (default: none).",
     )
     parser.add_argument(
@@ -1209,7 +1212,7 @@ def main() -> None:
         "count": args.scatter_count,
         "canonical_contigs": [],
     }
-    if args.scatter_mode == "interval":
+    if args.scatter_mode in ("chromosome", "interval"):
         scatter_config["canonical_contigs"] = parse_canonical_contigs(ref_data.get("dict"), build)
 
     # Build samples

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,3 +45,35 @@ def config_dict():
         },
         "extra_annotations": [],
     }
+
+
+@pytest.fixture
+def config_dict_chromosome():
+    """Configuration dictionary with chromosome scatter mode."""
+    return {
+        "ref": {
+            "genome": "/ref/GRCh38.p14.genome.fa",
+            "dict": "/ref/GRCh38.p14.genome.dict",
+        },
+        "paths": {
+            "samples": "config/samples.tsv",
+            "vcf_folder": "results/final",
+            "output_folder": "results/annotation",
+            "log_subdir": "logs",
+            "annotation_subdir": "annotation",
+        },
+        "snpeff": {
+            "database": "GRCh38.p14",
+            "extra_flags": "-lof -noInteraction",
+        },
+        "snpsift": {
+            "dbnsfp_db": "dbnsfp/dbNSFP4.9a_grch38.gz",
+            "dbnsfp_fields": "aaref,aaalt,SIFT_pred",
+        },
+        "scatter": {
+            "mode": "chromosome",
+            "count": 100,
+            "canonical_contigs": [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY"],
+        },
+        "extra_annotations": [],
+    }

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -628,3 +628,14 @@ class TestGenerateConfigTemplate:
         assert "LRT_pred" in content
         assert "FATHMM_score" in content
         assert "gnomAD_exomes_AF" in content
+
+    def test_scatter_config_chromosome_mode(self):
+        scatter = {
+            "mode": "chromosome",
+            "count": 100,
+            "canonical_contigs": ["chr1", "chr2", "chrX"],
+        }
+        content = generate_config_template(scatter_config=scatter, dry_run=True)
+        assert 'mode: "chromosome"' in content
+        assert '"chr1"' in content
+        assert '"chrX"' in content

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -64,9 +64,17 @@ class TestGetScatterUnits:
         result = get_scatter_units("chromosome", chromosomes=chroms)
         assert result == chroms
 
-    def test_chromosome_mode_no_chromosomes(self):
-        result = get_scatter_units("chromosome")
-        assert result == []
+    def test_chromosome_mode_no_chromosomes_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="non-empty"):
+            get_scatter_units("chromosome")
+
+    def test_chromosome_mode_empty_list_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="non-empty"):
+            get_scatter_units("chromosome", chromosomes=[])
 
     def test_chromosome_mode_grch37_contigs(self):
         contigs = ["1", "2", "3", "X", "Y"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,6 +59,28 @@ class TestGetScatterUnits:
         assert result[0] == "0000-scattered"
         assert result[99] == "0099-scattered"
 
+    def test_chromosome_mode(self):
+        chroms = ["chr1", "chr2", "chr3", "chrX", "chrY"]
+        result = get_scatter_units("chromosome", chromosomes=chroms)
+        assert result == chroms
+
+    def test_chromosome_mode_no_chromosomes(self):
+        result = get_scatter_units("chromosome")
+        assert result == []
+
+    def test_chromosome_mode_grch37_contigs(self):
+        contigs = ["1", "2", "3", "X", "Y"]
+        result = get_scatter_units("chromosome", chromosomes=contigs)
+        assert result == contigs
+
+    def test_interval_mode_unaffected_by_chromosomes(self):
+        result = get_scatter_units("interval", chromosomes=["chr1"], scatter_count=3)
+        assert result == ["0000-scattered", "0001-scattered", "0002-scattered"]
+
+    def test_none_mode_unaffected_by_chromosomes(self):
+        result = get_scatter_units("none", chromosomes=["chr1"])
+        assert result == ["all"]
+
 
 class TestGetVcfPath:
     def test_resolves_path(self, samples_df):
@@ -91,3 +113,11 @@ class TestAnnotationStepVcf:
     def test_step_two_with_scatter(self):
         result = annotation_step_vcf("/out/ann", "SampleA", 2, "0005-scattered")
         assert result == os.path.join("/out/ann", "SampleA.0005-scattered.ann.step2.vcf.gz")
+
+    def test_step_zero_with_chromosome(self):
+        result = annotation_step_vcf("/out/ann", "SampleA", 0, "chr1")
+        assert result == os.path.join("/out/ann", "SampleA.chr1.ann.dbnsfp.vcf.gz")
+
+    def test_step_one_with_chromosome(self):
+        result = annotation_step_vcf("/out/ann", "SampleA", 1, "chr1")
+        assert result == os.path.join("/out/ann", "SampleA.chr1.ann.step1.vcf.gz")

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -76,6 +76,16 @@ class TestConfigSchema:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(broken, config_schema)
 
+    def test_valid_chromosome_mode(self, config_dict_chromosome, config_schema):
+        jsonschema.validate(config_dict_chromosome, config_schema)
+
+    def test_ref_required_when_chromosome_scatter(self, config_dict, config_schema):
+        broken = copy.deepcopy(config_dict)
+        broken["scatter"]["mode"] = "chromosome"
+        del broken["ref"]
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(broken, config_schema)
+
     def test_extra_annotations_valid(self, config_dict, config_schema):
         valid = copy.deepcopy(config_dict)
         valid["extra_annotations"] = [

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -23,7 +23,7 @@ validate(samples_df, "schemas/samples.schema.yaml")
 # -- Wildcard constraints ----------------------------------------------------
 wildcard_constraints:
     sample="[A-Za-z0-9_.-]+",
-    scatter_unit="(all|[0-9]{4}-scattered)",
+    scatter_unit="(all|[0-9]{4}-scattered|chr[0-9XY]+|[0-9XY]+)",
     step="[0-9]+",
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -43,7 +43,11 @@ SCRATCH_DIR = os.environ.get("TMPDIR", "/tmp")
 
 
 # -- Scatter units -----------------------------------------------------------
-SCATTER_UNITS = _get_scatter_units_impl(SCATTER_MODE, CANONICAL_CONTIGS, SCATTER_COUNT)
+SCATTER_UNITS = _get_scatter_units_impl(
+    mode=SCATTER_MODE,
+    chromosomes=CANONICAL_CONTIGS,
+    scatter_count=SCATTER_COUNT,
+)
 
 
 # -- Sample accessors --------------------------------------------------------

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -43,7 +43,7 @@ SCRATCH_DIR = os.environ.get("TMPDIR", "/tmp")
 
 
 # -- Scatter units -----------------------------------------------------------
-SCATTER_UNITS = _get_scatter_units_impl(SCATTER_MODE, SCATTER_COUNT)
+SCATTER_UNITS = _get_scatter_units_impl(SCATTER_MODE, CANONICAL_CONTIGS, SCATTER_COUNT)
 
 
 # -- Sample accessors --------------------------------------------------------
@@ -81,8 +81,9 @@ def get_final_annotation_input(wildcards):
 def get_final_outputs():
     """Return all expected final output files.
 
-    Both modes produce {sample}.annotated.vcf.gz:
+    All modes produce {sample}.annotated.vcf.gz:
     - none: rename_no_scatter copies {sample}.all.annotated.vcf.gz
+    - chromosome: concatenate_annotated_vcfs merges per-chromosome files
     - interval: concatenate_annotated_vcfs merges per-interval files
     """
     samples = get_sample_list()

--- a/workflow/rules/helpers.py
+++ b/workflow/rules/helpers.py
@@ -32,7 +32,11 @@ def get_scatter_units(
     - mode="none": returns ["all"]
     """
     if mode == "chromosome":
-        return chromosomes or []
+        if not chromosomes:
+            raise ValueError(
+                "get_scatter_units(mode='chromosome') requires a non-empty 'chromosomes' list."
+            )
+        return chromosomes
     if mode == "interval":
         return [f"{i:04d}-scattered" for i in range(scatter_count)]
     return ["all"]

--- a/workflow/rules/helpers.py
+++ b/workflow/rules/helpers.py
@@ -20,12 +20,19 @@ def get_samples(samples_df: pd.DataFrame) -> list[str]:
     return sorted(samples_df["sample"].unique().tolist())
 
 
-def get_scatter_units(mode: str, scatter_count: int = 100) -> list[str]:
+def get_scatter_units(
+    mode: str,
+    chromosomes: list[str] | None = None,
+    scatter_count: int = 100,
+) -> list[str]:
     """Return the list of scatter units based on mode.
 
+    - mode="chromosome": returns the chromosome list (e.g. ["chr1", ..., "chrY"])
     - mode="interval": returns ["0000-scattered", "0001-scattered", ...]
     - mode="none": returns ["all"]
     """
+    if mode == "chromosome":
+        return chromosomes or []
     if mode == "interval":
         return [f"{i:04d}-scattered" for i in range(scatter_count)]
     return ["all"]

--- a/workflow/rules/scatter.smk
+++ b/workflow/rules/scatter.smk
@@ -38,7 +38,6 @@ elif SCATTER_MODE == "chromosome":
             echo "Starting scatter_vcf_chromosome at: $(date)" >> {log}
             bcftools view -r {wildcards.scatter_unit} {input.vcf_file} \
                 -Oz --threads {threads} -o {output} 2>> {log}
-            bcftools index --threads {threads} -t {output} 2>> {log}
             echo "Finished scatter_vcf_chromosome at: $(date)" >> {log}
             """
 

--- a/workflow/rules/scatter.smk
+++ b/workflow/rules/scatter.smk
@@ -22,6 +22,53 @@ if SCATTER_MODE == "none":
             echo "Done at: $(date)" >> {log}
             """
 
+elif SCATTER_MODE == "chromosome":
+
+    rule scatter_vcf_chromosome:
+        input:
+            vcf_file=get_input_vcf,
+        output:
+            temp(os.path.join(ANNOTATION_DIR, "{sample}.{scatter_unit}.vcf.gz")),
+        log:
+            os.path.join(LOG_DIR, "scatter_vcf_chromosome.{sample}.{scatter_unit}.log"),
+        conda:
+            "../envs/snpeff.yaml"
+        shell:
+            r"""
+            echo "Starting scatter_vcf_chromosome at: $(date)" >> {log}
+            bcftools view -r {wildcards.scatter_unit} {input.vcf_file} \
+                -Oz --threads {threads} -o {output} 2>> {log}
+            bcftools index --threads {threads} -t {output} 2>> {log}
+            echo "Finished scatter_vcf_chromosome at: $(date)" >> {log}
+            """
+
+    rule concatenate_annotated_vcfs:
+        # Identical to interval mode's concatenate rule — duplicated because
+        # Snakemake if/elif means only one branch's rules are defined.
+        input:
+            lambda wc: expand(
+                os.path.join(
+                    ANNOTATION_DIR,
+                    "{sample}.{scatter_unit}.annotated.vcf.gz",
+                ),
+                sample=[wc.sample],
+                scatter_unit=SCATTER_UNITS,
+            ),
+        output:
+            os.path.join(ANNOTATION_DIR, "{sample}.annotated.vcf.gz"),
+        log:
+            os.path.join(LOG_DIR, "concatenate_annotated_vcfs.{sample}.log"),
+        conda:
+            "../envs/snpeff.yaml"
+        shell:
+            r"""
+            echo "Starting concatenate_annotated_vcfs at: $(date)" >> {log}
+            bcftools concat -Oz --threads {threads} {input} \
+                -o {output} 2>> {log}
+            bcftools index --threads {threads} -t {output} 2>> {log}
+            echo "Finished concatenate_annotated_vcfs at: $(date)" >> {log}
+            """
+
 elif SCATTER_MODE == "interval":
 
     INTERVALS_LIST = os.path.join(INTERVALS_DIR, "intervals.interval_list")

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -5,7 +5,7 @@ type: object
 properties:
   ref:
     type: object
-    description: "Reference genome files. Required when scatter.mode is 'interval'."
+    description: "Reference genome files. Required when scatter.mode is 'interval' or 'chromosome'."
     properties:
       genome:
         type: string
@@ -63,8 +63,8 @@ properties:
     properties:
       mode:
         type: string
-        enum: ["interval", "none"]
-        description: "'interval' for GATK-based scattering, 'none' for single-pass."
+        enum: ["chromosome", "interval", "none"]
+        description: "'chromosome' for per-chromosome parallelization, 'interval' for GATK-based scattering, 'none' for single-pass."
       count:
         type: integer
         minimum: 1
@@ -74,7 +74,7 @@ properties:
         type: array
         items:
           type: string
-        description: List of canonical contigs to include when scattering.
+        description: List of canonical contigs to include when scattering (used by both chromosome and interval modes).
     required: [mode]
 
   extra_annotations:
@@ -93,12 +93,12 @@ properties:
 
 required: [paths, snpeff, snpsift, scatter]
 
-# Conditionally require ref when scatter.mode is "interval"
+# Conditionally require ref when scatter.mode is "interval" or "chromosome"
 if:
   properties:
     scatter:
       properties:
         mode:
-          const: "interval"
+          enum: ["interval", "chromosome"]
 then:
   required: [paths, snpeff, snpsift, scatter, ref]


### PR DESCRIPTION
Closes #15

## Summary

- Adds `scatter.mode: "chromosome"` that splits input VCFs by chromosome using `bcftools view -r`, runs annotation per chromosome in parallel (~24 units), and concatenates results with `bcftools concat`
- Provides a simpler middle ground between single-pass (`none`) and GATK interval-based scattering (`interval`) which caused OOM during DAG building with 100 scatter units
- Reuses existing `scatter.canonical_contigs` field (already populated by config generator from `.dict` files) — no new config fields needed

## Changes

### Core workflow
- `workflow/rules/helpers.py` — extend `get_scatter_units()` with `chromosomes` parameter
- `workflow/rules/common.smk` — pass `CANONICAL_CONTIGS` to scatter units call
- `workflow/Snakefile` — extend `scatter_unit` wildcard constraint for chromosome names
- `workflow/rules/scatter.smk` — add `scatter_vcf_chromosome` + `concatenate_annotated_vcfs` rules

### Config & validation
- `workflow/schemas/config.schema.yaml` — add `"chromosome"` to mode enum, require `ref` for it
- `profiles/default/config.v8+.yaml` — add `scatter_vcf_chromosome` resource entry (2 threads, 4 GB, 720 min)
- `scripts/generate_config.py` — add `"chromosome"` to CLI/wizard choices, populate contigs for both modes

### Tests (10 new, 124 total passing)
- `tests/test_helpers.py` — chromosome mode, GRCh37 contigs, mode isolation
- `tests/test_generate_config.py` — chromosome template test
- `tests/test_schema_validation.py` — valid chromosome config, ref required
- `tests/conftest.py` — chromosome config fixture

### Documentation
- `README.md`, `config/README.md` — updated scatter mode references and DAG diagrams

## Test plan

- [x] `make test-unit` — 124 passed, 1 skipped
- [x] `ruff check` — all checks passed
- [x] `snakefmt --check` — all files unchanged
- [x] `mypy` — no issues found
- [ ] Dry-run with chromosome config on HPC to verify DAG resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)