### PR TITLE
feat: add comprehensive QC reporting with MultiQC aggregation

### DIFF
--- a/profiles/default/config.v8+.yaml
+++ b/profiles/default/config.v8+.yaml
@@ -33,6 +33,10 @@ set-threads:
   scatter_vcf: 2
   scatter_vcf_chromosome: 2
   concatenate_annotated_vcfs: 4
+  bcftools_stats: 2
+  snpsift_tstv: 1
+  annotation_completeness: 1
+  multiqc: 1
 
 # Per-rule resource overrides
 # cpus_per_task mirrors set-threads as a workaround for
@@ -74,3 +78,19 @@ set-resources:
     mem_mb: 8192
     runtime: 1440
     cpus_per_task: 4
+  bcftools_stats:
+    mem_mb: 4000
+    runtime: 120
+    cpus_per_task: 2
+  snpsift_tstv:
+    mem_mb: 4000
+    runtime: 60
+    cpus_per_task: 1
+  annotation_completeness:
+    mem_mb: 4000
+    runtime: 120
+    cpus_per_task: 1
+  multiqc:
+    mem_mb: 4000
+    runtime: 30
+    cpus_per_task: 1

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,6 +12,8 @@ from helpers import (
     get_samples,
     get_scatter_units,
     get_vcf_path,
+    parse_annotation_completeness,
+    parse_snpsift_tstv,
 )
 
 
@@ -129,3 +131,86 @@ class TestAnnotationStepVcf:
     def test_step_one_with_chromosome(self):
         result = annotation_step_vcf("/out/ann", "SampleA", 1, "chr1")
         assert result == os.path.join("/out/ann", "SampleA.chr1.ann.step1.vcf.gz")
+
+
+class TestParseAnnotationCompleteness:
+    def test_all_annotated(self):
+        query = "chr1\t100\tA|missense\tD\t0.95\nchr1\t200\tA|synonymous\tT\t0.5\n"
+        fields = ["ANN", "SIFT_pred", "REVEL_score"]
+        result = parse_annotation_completeness(query, fields)
+        assert result["ANN"]["total"] == 2
+        assert result["ANN"]["annotated"] == 2
+        assert result["ANN"]["rate"] == 1.0
+        assert result["SIFT_pred"]["annotated"] == 2
+        assert result["REVEL_score"]["annotated"] == 2
+
+    def test_partial_annotation(self):
+        query = "chr1\t100\tA|missense\t.\t0.95\nchr1\t200\t.\tT\t.\n"
+        fields = ["ANN", "SIFT_pred", "REVEL_score"]
+        result = parse_annotation_completeness(query, fields)
+        assert result["ANN"]["total"] == 2
+        assert result["ANN"]["annotated"] == 1
+        assert result["ANN"]["rate"] == 0.5
+        assert result["SIFT_pred"]["annotated"] == 1
+        assert result["REVEL_score"]["annotated"] == 1
+
+    def test_empty_input(self):
+        result = parse_annotation_completeness("", ["ANN", "SIFT_pred"])
+        assert result["ANN"]["total"] == 0
+        assert result["ANN"]["annotated"] == 0
+        assert result["ANN"]["rate"] == 0.0
+
+    def test_all_missing(self):
+        query = "chr1\t100\t.\t.\nchr1\t200\t.\t.\n"
+        fields = ["ANN", "SIFT_pred"]
+        result = parse_annotation_completeness(query, fields)
+        assert result["ANN"]["annotated"] == 0
+        assert result["SIFT_pred"]["annotated"] == 0
+        assert result["ANN"]["rate"] == 0.0
+
+    def test_single_field(self):
+        query = "chr1\t100\tA|missense\nchr1\t200\t.\nchr1\t300\tB|stop\n"
+        fields = ["ANN"]
+        result = parse_annotation_completeness(query, fields)
+        assert result["ANN"]["total"] == 3
+        assert result["ANN"]["annotated"] == 2
+        assert result["ANN"]["rate"] == round(2 / 3, 4)
+
+
+class TestParseSnpsiftTstv:
+    def test_multi_sample(self):
+        output = (
+            "Sample        : 1       2       Total\n"
+            "Transitions   : 150488  160000  310488\n"
+            "Transversions : 70878   80000   150878\n"
+            "Ts/Tv         : 2.123   2.000   2.058\n"
+        )
+        result = parse_snpsift_tstv(output)
+        assert result["Transitions"] == "310488"
+        assert result["Transversions"] == "150878"
+        assert result["Ts/Tv"] == "2.058"
+
+    def test_single_sample(self):
+        output = (
+            "Sample        : 1       Total\n"
+            "Transitions   : 150488  150488\n"
+            "Transversions : 70878   70878\n"
+            "Ts/Tv         : 2.123   2.123\n"
+        )
+        result = parse_snpsift_tstv(output)
+        assert result["Transitions"] == "150488"
+        assert result["Transversions"] == "70878"
+        assert result["Ts/Tv"] == "2.123"
+
+    def test_empty_input(self):
+        result = parse_snpsift_tstv("")
+        assert result == {}
+
+    def test_skips_sample_row(self):
+        output = (
+            "Sample        : 1       Total\n"
+            "Transitions   : 100     100\n"
+        )
+        result = parse_snpsift_tstv(output)
+        assert "Sample" not in result
+        assert result["Transitions"] == "100"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -135,9 +135,12 @@ class TestAnnotationStepVcf:
 
 class TestParseAnnotationCompleteness:
     def test_all_annotated(self):
-        query = "chr1\t100\tA|missense\tD\t0.95\nchr1\t200\tA|synonymous\tT\t0.5\n"
+        lines = [
+            "chr1\t100\tA|missense\tD\t0.95\n",
+            "chr1\t200\tA|synonymous\tT\t0.5\n",
+        ]
         fields = ["ANN", "SIFT_pred", "REVEL_score"]
-        result = parse_annotation_completeness(query, fields)
+        result = parse_annotation_completeness(lines, fields)
         assert result["ANN"]["total"] == 2
         assert result["ANN"]["annotated"] == 2
         assert result["ANN"]["rate"] == 1.0
@@ -145,9 +148,12 @@ class TestParseAnnotationCompleteness:
         assert result["REVEL_score"]["annotated"] == 2
 
     def test_partial_annotation(self):
-        query = "chr1\t100\tA|missense\t.\t0.95\nchr1\t200\t.\tT\t.\n"
+        lines = [
+            "chr1\t100\tA|missense\t.\t0.95\n",
+            "chr1\t200\t.\tT\t.\n",
+        ]
         fields = ["ANN", "SIFT_pred", "REVEL_score"]
-        result = parse_annotation_completeness(query, fields)
+        result = parse_annotation_completeness(lines, fields)
         assert result["ANN"]["total"] == 2
         assert result["ANN"]["annotated"] == 1
         assert result["ANN"]["rate"] == 0.5
@@ -155,23 +161,27 @@ class TestParseAnnotationCompleteness:
         assert result["REVEL_score"]["annotated"] == 1
 
     def test_empty_input(self):
-        result = parse_annotation_completeness("", ["ANN", "SIFT_pred"])
+        result = parse_annotation_completeness([], ["ANN", "SIFT_pred"])
         assert result["ANN"]["total"] == 0
         assert result["ANN"]["annotated"] == 0
         assert result["ANN"]["rate"] == 0.0
 
     def test_all_missing(self):
-        query = "chr1\t100\t.\t.\nchr1\t200\t.\t.\n"
+        lines = ["chr1\t100\t.\t.\n", "chr1\t200\t.\t.\n"]
         fields = ["ANN", "SIFT_pred"]
-        result = parse_annotation_completeness(query, fields)
+        result = parse_annotation_completeness(lines, fields)
         assert result["ANN"]["annotated"] == 0
         assert result["SIFT_pred"]["annotated"] == 0
         assert result["ANN"]["rate"] == 0.0
 
     def test_single_field(self):
-        query = "chr1\t100\tA|missense\nchr1\t200\t.\nchr1\t300\tB|stop\n"
+        lines = [
+            "chr1\t100\tA|missense\n",
+            "chr1\t200\t.\n",
+            "chr1\t300\tB|stop\n",
+        ]
         fields = ["ANN"]
-        result = parse_annotation_completeness(query, fields)
+        result = parse_annotation_completeness(lines, fields)
         assert result["ANN"]["total"] == 3
         assert result["ANN"]["annotated"] == 2
         assert result["ANN"]["rate"] == round(2 / 3, 4)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -32,6 +32,7 @@ include: "rules/common.smk"
 include: "rules/scatter.smk"
 include: "rules/snpeff.smk"
 include: "rules/snpsift.smk"
+include: "rules/qc.smk"
 
 
 # -- Target rule -------------------------------------------------------------

--- a/workflow/envs/multiqc.yaml
+++ b/workflow/envs/multiqc.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - multiqc>=1.25

--- a/workflow/report/multiqc_config.yaml
+++ b/workflow/report/multiqc_config.yaml
@@ -1,0 +1,12 @@
+report_header_info:
+  - Pipeline: "sm-vcf-annotation"
+
+top_modules:
+  - snpeff
+  - bcftools
+  - custom_content
+
+extra_fn_clean_exts:
+  - ".annotated"
+  - ".ann"
+  - ".bcftools_stats"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -24,6 +24,7 @@ ANNOTATION_SUBDIR = config["paths"].get("annotation_subdir", "annotation")
 
 ANNOTATION_DIR = os.path.join(OUTPUT_DIR, ANNOTATION_SUBDIR)
 LOG_DIR = os.path.join(OUTPUT_DIR, LOG_SUBDIR)
+QC_DIR = os.path.join(OUTPUT_DIR, "qc")
 INTERVALS_DIR = os.path.join(OUTPUT_DIR, "intervals")
 
 SNPEFF_DB = config["snpeff"]["database"]
@@ -89,9 +90,13 @@ def get_final_outputs():
     - none: rename_no_scatter copies {sample}.all.annotated.vcf.gz
     - chromosome: concatenate_annotated_vcfs merges per-chromosome files
     - interval: concatenate_annotated_vcfs merges per-interval files
+
+    Also includes the aggregated MultiQC report from QC rules.
     """
     samples = get_sample_list()
-    return expand(
+    annotated = expand(
         os.path.join(ANNOTATION_DIR, "{sample}.annotated.vcf.gz"),
         sample=samples,
     )
+    qc = [os.path.join(QC_DIR, "multiqc_report.html")]
+    return annotated + qc

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -1,0 +1,165 @@
+"""QC rules: bcftools stats, SnpSift tstv, annotation completeness, and MultiQC."""
+
+from rules.helpers import parse_annotation_completeness, parse_snpsift_tstv
+
+
+rule bcftools_stats:
+    input:
+        vcf=os.path.join(ANNOTATION_DIR, "{sample}.annotated.vcf.gz"),
+    output:
+        stats=os.path.join(QC_DIR, "{sample}.bcftools_stats.txt"),
+    log:
+        os.path.join(LOG_DIR, "bcftools_stats.{sample}.log"),
+    benchmark:
+        os.path.join(LOG_DIR, "benchmarks/bcftools_stats.{sample}.tsv")
+    conda:
+        "../envs/snpeff.yaml"
+    shell:
+        r"""
+        echo "Starting bcftools_stats at: $(date)" > {log}
+        bcftools stats --threads {threads} {input.vcf} > {output.stats} 2>> {log}
+        echo "Finished bcftools_stats at: $(date)" >> {log}
+        """
+
+
+rule snpsift_tstv:
+    input:
+        vcf=os.path.join(ANNOTATION_DIR, "{sample}.annotated.vcf.gz"),
+    output:
+        tstv=os.path.join(QC_DIR, "{sample}.snpsift_tstv_mqc.tsv"),
+    log:
+        os.path.join(LOG_DIR, "snpsift_tstv.{sample}.log"),
+    benchmark:
+        os.path.join(LOG_DIR, "benchmarks/snpsift_tstv.{sample}.tsv")
+    params:
+        java_opts=get_java_opts,
+    conda:
+        "../envs/snpeff.yaml"
+    run:
+        import subprocess
+
+        shell("echo 'Starting snpsift_tstv at: $(date)' > {log}")
+        result = subprocess.run(
+            f"SnpSift {params.java_opts} tstv {input.vcf}",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            with open(str(log), "a") as lf:
+                lf.write(f"SnpSift tstv stderr: {result.stderr}\n")
+        tstv = parse_snpsift_tstv(result.stdout)
+        with open(str(output.tstv), "w") as fh:
+            fh.write("# id: 'snpsift_tstv'\n")
+            fh.write("# section_name: 'SnpSift Ts/Tv'\n")
+            fh.write("# description: 'Transition / transversion ratios from SnpSift'\n")
+            fh.write("# format: 'tsv'\n")
+            fh.write("# plot_type: 'generalstats'\n")
+            fh.write("# pconfig:\n")
+            fh.write("#     - Transitions:\n")
+            fh.write("#         title: 'Transitions'\n")
+            fh.write("#         format: '{:,.0f}'\n")
+            fh.write("#     - Transversions:\n")
+            fh.write("#         title: 'Transversions'\n")
+            fh.write("#         format: '{:,.0f}'\n")
+            fh.write("#     - Ts/Tv:\n")
+            fh.write("#         title: 'Ts/Tv'\n")
+            fh.write("#         min: 0\n")
+            fh.write("#         format: '{:.3f}'\n")
+            cols = ["Transitions", "Transversions", "Ts/Tv"]
+            fh.write("Sample\t" + "\t".join(cols) + "\n")
+            vals = [tstv.get(c, "") for c in cols]
+            fh.write(f"{wildcards.sample}\t" + "\t".join(vals) + "\n")
+        shell("echo 'Finished snpsift_tstv at: $(date)' >> {log}")
+
+
+rule annotation_completeness:
+    input:
+        vcf=os.path.join(ANNOTATION_DIR, "{sample}.annotated.vcf.gz"),
+    output:
+        tsv=os.path.join(QC_DIR, "{sample}.annotation_completeness_mqc.tsv"),
+    log:
+        os.path.join(LOG_DIR, "annotation_completeness.{sample}.log"),
+    benchmark:
+        os.path.join(LOG_DIR, "benchmarks/annotation_completeness.{sample}.tsv")
+    params:
+        fields=["ANN", "dbNSFP_SIFT_pred", "dbNSFP_REVEL_score"],
+    conda:
+        "../envs/snpeff.yaml"
+    run:
+        import subprocess
+
+        shell("echo 'Starting annotation_completeness at: $(date)' > {log}")
+        field_fmt = "\t".join([f"%{f}" for f in params.fields])
+        query_cmd = f"bcftools query -f '%CHROM\\t%POS\\t{field_fmt}\\n' {input.vcf}"
+        result = subprocess.run(
+            query_cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            with open(str(log), "a") as lf:
+                lf.write(f"bcftools query stderr: {result.stderr}\n")
+        query_output = result.stdout
+        stats = parse_annotation_completeness(query_output, list(params.fields))
+
+        with open(str(output.tsv), "w") as fh:
+            fh.write("# id: 'annotation_completeness'\n")
+            fh.write("# section_name: 'Annotation Completeness'\n")
+            fh.write("# description: 'Fraction of variants with non-missing annotation values'\n")
+            fh.write("# format: 'tsv'\n")
+            fh.write("# plot_type: 'generalstats'\n")
+            fh.write("# pconfig:\n")
+            for field in params.fields:
+                fh.write(f"#     - {field}_rate:\n")
+                fh.write(f"#         title: '{field} rate'\n")
+                fh.write("#         min: 0\n")
+                fh.write("#         max: 1\n")
+                fh.write("#         format: '{:.2%}'\n")
+            fh.write("Sample\t" + "\t".join([f"{f}_rate" for f in params.fields]) + "\n")
+            rates = [str(stats[f]["rate"]) for f in params.fields]
+            fh.write(f"{wildcards.sample}\t" + "\t".join(rates) + "\n")
+        shell("echo 'Finished annotation_completeness at: $(date)' >> {log}")
+
+
+rule multiqc:
+    input:
+        bcftools=expand(
+            os.path.join(QC_DIR, "{sample}.bcftools_stats.txt"),
+            sample=get_sample_list(),
+        ),
+        tstv=expand(
+            os.path.join(QC_DIR, "{sample}.snpsift_tstv_mqc.tsv"),
+            sample=get_sample_list(),
+        ),
+        completeness=expand(
+            os.path.join(QC_DIR, "{sample}.annotation_completeness_mqc.tsv"),
+            sample=get_sample_list(),
+        ),
+        snpeff_csv=expand(
+            os.path.join(QC_DIR, "snpeff_stats.{sample}.{scatter_unit}.csv"),
+            sample=get_sample_list(),
+            scatter_unit=SCATTER_UNITS,
+        ),
+    output:
+        html=os.path.join(QC_DIR, "multiqc_report.html"),
+        data=directory(os.path.join(QC_DIR, "multiqc_data")),
+    log:
+        os.path.join(LOG_DIR, "multiqc.log"),
+    benchmark:
+        os.path.join(LOG_DIR, "benchmarks/multiqc.tsv")
+    params:
+        qc_dir=QC_DIR,
+        mqc_config=workflow.source_path("../report/multiqc_config.yaml"),
+    conda:
+        "../envs/multiqc.yaml"
+    shell:
+        r"""
+        echo "Starting multiqc at: $(date)" > {log}
+        multiqc {params.qc_dir} \
+            --config {params.mqc_config} \
+            --outdir {params.qc_dir} \
+            --force 2>> {log}
+        echo "Finished multiqc at: $(date)" >> {log}
+        """

--- a/workflow/rules/snpeff.smk
+++ b/workflow/rules/snpeff.smk
@@ -15,6 +15,14 @@ rule snpeff_annotation:
                 "{sample}.{scatter_unit}.ann.vcf.gz",
             )
         ),
+        stats_csv=os.path.join(
+            QC_DIR,
+            "snpeff_stats.{sample}.{scatter_unit}.csv",
+        ),
+        genes_txt=os.path.join(
+            QC_DIR,
+            "snpeff_stats.{sample}.{scatter_unit}.genes.txt",
+        ),
     log:
         os.path.join(LOG_DIR, "snpeff_annotation.{sample}.{scatter_unit}.log"),
     benchmark:
@@ -23,14 +31,13 @@ rule snpeff_annotation:
         java_opts=get_java_opts,
         db=SNPEFF_DB,
         extra_flags=SNPEFF_EXTRA_FLAGS,
-        stats_html=os.path.join(LOG_DIR, "snpeff_stats.{sample}.{scatter_unit}.html"),
     conda:
         "../envs/snpeff.yaml"
     shell:
         r"""
         echo "Starting snpeff_annotation at: $(date)" >> {log}
         snpEff {params.java_opts} {params.db} {params.extra_flags} \
-            -stats {params.stats_html} {input.vcf_file} \
+            -csvStats {output.stats_csv} {input.vcf_file} \
         | bgzip -c > {output.ann_vcf} 2>> {log}
         echo "Finished snpeff_annotation at: $(date)" >> {log}
         """


### PR DESCRIPTION
## Summary

- **snpEff stats fix**: switch from untracked HTML (`-stats` in `params`) to machine-readable CSV (`-csvStats` as proper `output:`), with genes.txt also tracked — both written to new `qc/` directory
- **4 new QC rules** in `workflow/rules/qc.smk`: `bcftools_stats`, `snpsift_tstv`, `annotation_completeness`, and `multiqc` aggregation
- **MultiQC integration**: snpEff CSV stats (native module), bcftools stats (native module), SnpSift Ts/Tv and annotation completeness rates (custom content `_mqc.tsv` with embedded YAML headers using correct `generalstats` pconfig list format)
- **2 new helper functions** in `helpers.py`: `parse_annotation_completeness()` and `parse_snpsift_tstv()` — pure Python, no Snakemake imports, fully unit-tested
- **Profile resources** for all 4 new rules in `profiles/default/config.v8+.yaml`
- **Always-on**: no config knobs needed — QC runs automatically via `get_final_outputs()` requesting `qc/multiqc_report.html`

### New files
| File | Purpose |
|------|---------|
| `workflow/rules/qc.smk` | 4 QC rules (bcftools_stats, snpsift_tstv, annotation_completeness, multiqc) |
| `workflow/envs/multiqc.yaml` | Conda env (`multiqc>=1.25`) |
| `workflow/report/multiqc_config.yaml` | MultiQC config (`top_modules`, filename cleaning) |

### Modified files
| File | Change |
|------|--------|
| `workflow/rules/snpeff.smk` | `-stats` → `-csvStats`, CSV + genes.txt as `output:` in QC_DIR |
| `workflow/rules/common.smk` | Add `QC_DIR`, update `get_final_outputs()` |
| `workflow/rules/helpers.py` | Add `parse_annotation_completeness()`, `parse_snpsift_tstv()` |
| `workflow/Snakefile` | Add `include: "rules/qc.smk"` |
| `profiles/default/config.v8+.yaml` | Threads + resources for QC rules |
| `tests/test_helpers.py` | 9 new tests (5 completeness + 4 tstv) |

## Test plan

- [x] `ruff check` + `ruff format --check` — pass
- [x] `mypy` — pass
- [x] `snakefmt --check` — all 6 .smk files pass
- [x] `pytest tests/test_helpers.py` — 30/30 pass (9 new + 21 existing)
- [ ] Dry-run test with snakemake on PATH to verify DAG resolution
- [ ] End-to-end run on a real VCF to confirm MultiQC report generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)