### PR TITLE
fix: replace subprocess calls with shell() in QC run blocks

### DIFF
--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -36,20 +36,12 @@ rule snpsift_tstv:
     conda:
         "../envs/snpeff.yaml"
     run:
-        import subprocess
-
         shell("echo 'Starting snpsift_tstv at: $(date)' > {log}")
-        result = subprocess.run(
-            f"SnpSift {params.java_opts} tstv {input.vcf}",
-            shell=True,
-            capture_output=True,
-            text=True,
+        stdout = shell(
+            "SnpSift {params.java_opts} tstv {input.vcf} 2>> {log}",
+            read=True,
         )
-        if result.returncode != 0:
-            with open(str(log), "a") as lf:
-                lf.write(f"SnpSift tstv stderr: {result.stderr}\n")
-            raise RuntimeError("SnpSift tstv failed; see log for details.")
-        tstv = parse_snpsift_tstv(result.stdout)
+        tstv = parse_snpsift_tstv(stdout)
         with open(str(output.tstv), "w") as fh:
             fh.write("# id: 'snpsift_tstv'\n")
             fh.write("# section_name: 'SnpSift Ts/Tv'\n")
@@ -88,25 +80,11 @@ rule annotation_completeness:
     conda:
         "../envs/snpeff.yaml"
     run:
-        import subprocess
-
         shell("echo 'Starting annotation_completeness at: $(date)' > {log}")
-        field_fmt = "\t".join([f"%{f}" for f in params.fields])
-        query_cmd = f"bcftools query -f '%CHROM\\t%POS\\t{field_fmt}\\n' {input.vcf}"
-        proc = subprocess.Popen(
-            query_cmd,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        stats = parse_annotation_completeness(proc.stdout, list(params.fields))
-        stderr = proc.stderr.read()
-        returncode = proc.wait()
-        if returncode != 0:
-            with open(str(log), "a") as lf:
-                lf.write(f"bcftools query stderr: {stderr}\n")
-            raise RuntimeError("bcftools query failed; see log for details.")
+        field_fmt = "\\t".join([f"%{f}" for f in params.fields])
+        cmd = f"bcftools query -f '%CHROM\\t%POS\\t{field_fmt}\\n' {{input.vcf}} 2>> {{log}}"
+        stdout = shell(cmd, read=True)
+        stats = parse_annotation_completeness(stdout.splitlines(), list(params.fields))
 
         with open(str(output.tsv), "w") as fh:
             fh.write("# id: 'annotation_completeness'\n")


### PR DESCRIPTION
## Summary

- Replace `subprocess.run(shell=True)` / `subprocess.Popen(shell=True)` with Snakemake's `shell(read=True)` in `snpsift_tstv` and `annotation_completeness` rules
- This ensures the conda-activated PATH is inherited when commands execute on SLURM worker nodes
- Stderr is redirected to log files; error handling is delegated to Snakemake's built-in `CalledProcessError`

## Root Cause

`run:` blocks with `subprocess.run(shell=True)` spawn a new `/bin/sh` that does **not** inherit the conda environment's PATH. Snakemake only prepends conda activation for its own `shell()` function, not for raw subprocess calls. This caused `SnpSift: command not found` and `bcftools: command not found` on SLURM.

## Changes

| Rule | Before | After |
|------|--------|-------|
| `snpsift_tstv` | `subprocess.run(..., shell=True, capture_output=True)` | `shell("... 2>> {log}", read=True)` |
| `annotation_completeness` | `subprocess.Popen(..., shell=True, stdout=PIPE)` | `shell(cmd, read=True)` + `stdout.splitlines()` |

## Test plan

- [x] `snakefmt --check workflow/rules/qc.smk` passes
- [x] All 30 unit tests pass (`pytest tests/test_helpers.py`)
- [ ] Dry-run on HPC with `--use-conda`
- [ ] Full pipeline run on SLURM verifying QC outputs are generated

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)